### PR TITLE
fix: update js-yaml to 3.15.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13764,9 +13764,9 @@
       "dev": true
     },
     "node_modules/js-yaml": {
-      "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "dependencies": {
         "argparse": "^1.0.7",


### PR DESCRIPTION
Updates the resolved root `js-yaml` package from 3.13.1 to 3.15.1, the patched release for GHSA-5p4m-2wfm-xmqj (CVE-2026-59870). Parent semver ranges already accept 3.15.1; nested `js-yaml@4.3.1` remains unchanged.